### PR TITLE
Update `Coverage` to version `6.2`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.5" %}
+{% set version = "6.1.1" %}
 
 package:
   name: coverage
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/coverage/coverage-{{ version }}.tar.gz
-  sha256: ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c
+  sha256: b8e4f15b672c9156c1154249a9c5746e86ac9ae9edc3799ee3afebc323d9d9e0
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,11 @@ requirements:
 test:
   imports:
     - coverage
-
+  requires:
+    - pip
   commands:
     - coverage --help
+    - pip check
 
 about:
   home: https://coverage.readthedocs.io
@@ -42,7 +44,10 @@ about:
     effectiveness of tests. It can show which parts of your code are being
     exercised by tests, and which are not.
   doc_url: http://coverage.readthedocs.org
-  dev_url: https://bitbucket.org/ned/coveragepy
+  # the old dev_url is deprecated dev_url: https://bitbucket.org/ned/coveragepy
+  # the new dev_url was taken from read the docs
+  dev_url: https://github.com/nedbat/coveragepy
+  # the doc_source_url: seems to be deprecated
   doc_source_url: https://bitbucket.org/ned/coveragepy/src/default/doc/?at=default
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ about:
     exercised by tests, and which are not.
   doc_url: https://coverage.readthedocs.org
   dev_url: https://github.com/nedbat/coveragepy
-  doc_source_url: https://github.com/nedbat/coveragepy/blob/master/doc/index.rst
+  doc_source_url: https://github.com/nedbat/coveragepy/tree/6.2/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ about:
     but was not. Coverage measurement is typically used to gauge the
     effectiveness of tests. It can show which parts of your code are being
     exercised by tests, and which are not.
-  doc_url: http://coverage.readthedocs.org
+  doc_url: https://coverage.readthedocs.org
   dev_url: https://github.com/nedbat/coveragepy
   doc_source_url: https://github.com/nedbat/coveragepy/blob/master/doc/index.rst
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.1.1" %}
+{% set version = "6.2" %}
 
 package:
   name: coverage
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/coverage/coverage-{{ version }}.tar.gz
-  sha256: b8e4f15b672c9156c1154249a9c5746e86ac9ae9edc3799ee3afebc323d9d9e0
+  sha256: e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8
 
 build:
-  number: 2
+  number: 0
   entry_points:
     - coverage = coverage.cmdline:main
 
@@ -19,6 +19,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
@@ -33,7 +35,8 @@ test:
 
 about:
   home: https://coverage.readthedocs.io
-  license: Apache 2.0
+  license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE.txt
   summary: Code coverage measurement for Python
   description: |
@@ -44,11 +47,8 @@ about:
     effectiveness of tests. It can show which parts of your code are being
     exercised by tests, and which are not.
   doc_url: http://coverage.readthedocs.org
-  # the old dev_url is deprecated dev_url: https://bitbucket.org/ned/coveragepy
-  # the new dev_url was taken from read the docs
   dev_url: https://github.com/nedbat/coveragepy
-  # the doc_source_url: seems to be deprecated
-  doc_source_url: https://bitbucket.org/ned/coveragepy/src/default/doc/?at=default
+  doc_source_url: https://github.com/nedbat/coveragepy/blob/master/doc/index.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ build:
   number: 0
   entry_points:
     - coverage = coverage.cmdline:main
+   skip: True  # [py<36]
 
 requirements:
   build:


### PR DESCRIPTION

  `coverage` version `6.1.1`
1. check the upstream
    https://github.com/nedbat/coveragepy/tree/6.1.1

2. check the pinnings
    https://github.com/nedbat/coveragepy/blob/6.1.1/tox.ini

    https://github.com/nedbat/coveragepy/blob/6.1.1/setup.py

    https://github.com/nedbat/coveragepy/blob/6.1.1/setup.cfg

    https://github.com/nedbat/coveragepy/blob/6.1.1/metacov.ini

    https://github.com/nedbat/coveragepy/blob/6.1.1/igor.py

3. check the changelogs
    https://github.com/nedbat/coveragepy/blob/6.1.1/CHANGES.rst

4. additional research
    https://github.com/conda-forge/coverage-feedstock/issues

    There were no open issues mentioned at the time of the review on `conda-forge`

5. verify dev_url
    The old dev_url: does not seem to work
    dev_url: https://bitbucket.org/ned/coveragepy

    The following url seems to be available in read the docs
    https://github.com/nedbat/coveragepy

6. verify doc_url
    http://coverage.readthedocs.org

7. pip is in the test section
8. veriy the test section
9. additional tests

In order to test the `coverage` package version `6.1.1` the folowing
command was used:
`conda build coverage-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `coverage` to version `6.1.1`
