### PR TITLE
coverage 7.6.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,4 @@
-%PYTHON% -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+%PYTHON% -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 :: Remove versioned entrypoints.
 %PYTHON% -c "import os; print('_'.join(os.environ['PY_VER'].split('.')[0]))" > temp.txt

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-$PYTHON -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+$PYTHON -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 # Remove versioned entrypoints.
 PY_VER_MAJ=$($PYTHON -c "import os; print('_'.join(os.environ['PY_VER'].split('.')[0]))")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "coverage" %}
-{% set version = "7.2.2" %}
+{% set version = "7.6.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/coverage-{{ version }}.tar.gz
-  sha256: 36dd42da34fe94ed98c39887b86db9d06777b1c8f860520e21126a75507024f2
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   entry_points:
     - coverage = coverage.cmdline:main
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4734](https://anaconda.atlassian.net/browse/PKG-4734) 
- [Upstream repository](https://github.com/nedbat/coveragepy/tree/7.6.1)
- Requirements:
  - https://github.com/nedbat/coveragepy/blob/7.6.1/pyproject.toml
  - https://github.com/nedbat/coveragepy/blob/7.6.1/setup.py 

### Explanation of changes:

- Add `--no-build-isolation` to build scripts
- Skip `py<38`


[PKG-4734]: https://anaconda.atlassian.net/browse/PKG-4734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ