### PR TITLE
Fix missing `tracer` module on Windows

### DIFF
--- a/recipe/0001-force-extension-module-creation.patch
+++ b/recipe/0001-force-extension-module-creation.patch
@@ -1,0 +1,35 @@
+From f1184a63e0dae1340defbd1d44543f822017ca8b Mon Sep 17 00:00:00 2001
+From: Brian Wing <bwing@anaconda.com>
+Date: Mon, 17 Nov 2025 12:09:28 -0500
+Subject: [PATCH] Force extension module creation
+
+---
+ setup.py | 13 ++-----------
+ 1 file changed, 2 insertions(+), 11 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 36d6f606b..6d7a42b17 100644
+--- a/setup.py
++++ b/setup.py
+@@ -207,17 +207,8 @@ if compile_extension:
+ 
+ def main():
+     """Actually invoke setup() with the arguments we built above."""
+-    # For a variety of reasons, it might not be possible to install the C
+-    # extension.  Try it with, and if it fails, try it without.
+-    try:
+-        setup(**setup_args)
+-    except BuildFailed as exc:
+-        msg = "Couldn't install with extension module, trying without it..."
+-        exc_msg = f"{exc.__class__.__name__}: {exc.cause}"
+-        print(f"**\n** {msg}\n** {exc_msg}\n**")
+-
+-        del setup_args["ext_modules"]
+-        setup(**setup_args)
++    # Force the creation of the extension module.
++    setup(**setup_args)
+ 
+ 
+ if __name__ == "__main__":
+-- 
+2.51.1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,5 @@
 %PYTHON% -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+if %ERRORLEVEL% neq 0 exit %ERRORLEVEL%
 
 :: Remove versioned entrypoints.
 %PYTHON% -c "import os; print('_'.join(os.environ['PY_VER'].split('.')[0]))" > temp.txt

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler:
+  - vs2022   # [win]
+cxx_compiler:
+  - vs2022   # [win]
+c_stdlib_version:
+  - 2022.12  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 167bd504ac1ca2af7ff3b81d245dfea0292c5032ebef9d66cc08a7d28c1b8050
+  patches:
+    - 0001-force-extension-module-creation.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<310]
   entry_points:
     - coverage = coverage.cmdline:main
@@ -50,6 +52,7 @@ test:
     - coverage.data
     - coverage.debug
     - coverage.disposition
+    - coverage.env
     - coverage.exceptions
     - coverage.execfile
     - coverage.files
@@ -76,6 +79,7 @@ test:
     - coverage.sysmon
     - coverage.templite
     - coverage.tomlconfig
+    - coverage.tracer
     - coverage.types
     - coverage.version
     - coverage.xmlreport


### PR DESCRIPTION
coverage 7.11.0 b1

**Destination channel:** defaults

### Links

- [PKG-10847](https://anaconda.atlassian.net/browse/PKG-10847)
- [Upstream repository](https://github.com/coveragepy/coveragepy/tree/7.11.0)
- [Upstream changelog/diff](https://github.com/coveragepy/coveragepy/blob/7.11.0/CHANGES.rst)
- Relevant dependency PRs:
  - AnacondaRecipes/click-loglevel-feedstock#1

### Explanation of changes:

- Removed upstream try/catch around extension module building so the build will actually fail if it doesn't get made
- Enabled tests for all modules in package
- Added failure check on pip install command
- Use new enough compiler on Windows to build `coverage.tracer` module


[PKG-10847]: https://anaconda.atlassian.net/browse/PKG-10847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ