### PR TITLE
coverage 7.13.4 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "coverage" %}
-{% set version = "7.11.0" %}
+{% set version = "7.13.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,15 +7,15 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 167bd504ac1ca2af7ff3b81d245dfea0292c5032ebef9d66cc08a7d28c1b8050
+  sha256: e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91
   patches:
     - 0001-force-extension-module-creation.patch
 
 build:
-  number: 1
-  skip: True  # [py<310]
+  number: 0
   entry_points:
     - coverage = coverage.cmdline:main
+  skip: true  # [py<310]
 
 requirements:
   build:


### PR DESCRIPTION
coverage 7.13.4 

**Destination channel:** Defaults

### Links

- [PKG-12363]
- dev_url:        https://github.com/nedbat/coveragepy/tree/7.13.4
- conda_forge:    https://github.com/conda-forge/coverage-feedstock
- pypi:           https://pypi.org/project/coverage/7.13.4
- pypi inspector: https://inspector.pypi.io/project/coverage/7.13.4

### Explanation of changes:

- new version number


[PKG-12363]: https://anaconda.atlassian.net/browse/PKG-12363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ